### PR TITLE
Turn the Ubuntu Precise service provider into a Legacy provider

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ Samhain Cookbook CHANGELOG
 
 v?.?.? (????-??-??)
 -------------------
-- Add support for Ubuntu 12.04
+- Add support for legacy versions of Ubuntu (with testing done against 12.04)
 
 v0.3.0 (2015-12-21)
 -------------------

--- a/README.md
+++ b/README.md
@@ -16,8 +16,9 @@ Requirements
 ============
 
 This cookbook currently supports Ubuntu only and is actively tested against
-15.10, 14.04, and 12.04. The hope is to support other platforms as well in the
-future.
+15.04, 14.04, and 12.04 while also attempting to maintain (untested)
+compatibility with 10.04. The hope is to support other platforms as well in
+the future.
 
 Assorted older Chef and Ruby conventions are intentionally used to (for now)
 maintain compatibility with Chef 11.
@@ -54,13 +55,17 @@ samhainrc is not a perfect hash, the syntax for adding attributes is a bit
 different. 
 
 To overwrite regular attributes:
+
 ```ruby
     ['samhain']['config']['Misc']['bacon'] = 'Applewood Smoked'
 ```
+
 To add files or directories for monitoring: 
+
 ```ruby
     ['samhain']['config']['LogFiles']['file']['path/to/my/file'] = true
 ```
+
 ## Usage
 The intent of the attributes file is to allow
 service owners to add files to the Samhain watchlist. 

--- a/libraries/provider_mapping.rb
+++ b/libraries/provider_mapping.rb
@@ -26,7 +26,7 @@ require_relative 'provider_samhain_app_ubuntu'
 require_relative 'provider_samhain_config'
 require_relative 'provider_samhain_service'
 require_relative 'provider_samhain_service_ubuntu_trusty'
-require_relative 'provider_samhain_service_ubuntu_precise'
+require_relative 'provider_samhain_service_ubuntu_legacy'
 
 if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12')
   Chef::Platform.set(resource: :samhain,
@@ -44,6 +44,6 @@ if Gem::Version.new(Chef::VERSION) < Gem::Version.new('12')
                      provider: Chef::Provider::SamhainService::Ubuntu::Trusty)
   Chef::Platform.set(resource: :samhain_service,
                      platform: :ubuntu,
-                     version: '12.04',
-                     provider: Chef::Provider::SamhainService::Ubuntu::Precise)
+                     version: '< 14.04',
+                     provider: Chef::Provider::SamhainService::Ubuntu::Legacy)
 end

--- a/libraries/provider_samhain_service_ubuntu_legacy.rb
+++ b/libraries/provider_samhain_service_ubuntu_legacy.rb
@@ -1,7 +1,7 @@
 # Encoding: UTF-8
 #
 # Cookbook Name:: samhain
-# Library:: provider_samhain_service_ubuntu_precise
+# Library:: provider_samhain_service_ubuntu_legacy
 #
 # Copyright 2015 Socrata, Inc.
 #
@@ -25,22 +25,25 @@ class Chef
   class Provider
     class SamhainService < LWRPBase
       class Ubuntu
-        # A customized Samhain service provider for Ubuntu 12.04, where the
-        # init script exits before the service is completely started.
+        # A customized Samhain service provider for versions Ubuntu < 14.04
+        # because:
+        #
+        #   * Ubuntu 12.04's init script exits before the service is finished
+        #     starting, causing a race condition when Chef is trying to figure
+        #     out the service's status.
+        #   * Ubuntu 10.04's init script lacked a :reload action entirely.
         #
         # @author Jonathan Hartman <jonathan.hartman@socrata.com>
-        class Precise < SamhainService
+        class Legacy < SamhainService
           if defined?(provides)
             provides :samhain_service,
                      platform: 'ubuntu',
-                     platform_version: '12.04'
+                     platform_version: '< 14.04'
           end
 
           #
-          # Override the normal service resource to use a custom status check
-          # command. This should circumvent the race conditions that arise
-          # from the init script on Precise exiting before its status check
-          # considers the service fully "started".
+          # Override the normal service resource to not use the init script's
+          # status check, if available.
           #
           # (see Chef::Provider::SamhainService#samhain_service)
           #

--- a/spec/libraries/provider_mapping_spec.rb
+++ b/spec/libraries/provider_mapping_spec.rb
@@ -95,7 +95,34 @@ describe :provider_mapping do
         expect(provider).to eq(Chef::Provider::Samhain)
         expect(app_provider).to eq(Chef::Provider::SamhainApp::Ubuntu)
         expect(service_provider).to eq(
-          Chef::Provider::SamhainService::Ubuntu::Precise
+          Chef::Provider::SamhainService::Ubuntu::Legacy
+        )
+      end
+    end
+  end
+
+  context 'Ubuntu 10.04' do
+    let(:platform) { { platform: 'ubuntu', version: '10.04' } }
+
+    context 'Chef 12' do
+      let(:chef_version) { '12.4.1' }
+
+      it_behaves_like 'Chef 12'
+    end
+
+    context 'Chef 11' do
+      let(:chef_version) { '11.16.4' }
+
+      it 'sets up old-style provider mappings' do
+        allow(Chef::Log).to receive(:warn)
+        expect(Chef::Platform).to receive(:set).at_least(1).times
+          .and_call_original
+        load(File.expand_path('../../../libraries/provider_mapping.rb',
+                              __FILE__))
+        expect(provider).to eq(Chef::Provider::Samhain)
+        expect(app_provider).to eq(Chef::Provider::SamhainApp::Ubuntu)
+        expect(service_provider).to eq(
+          Chef::Provider::SamhainService::Ubuntu::Legacy
         )
       end
     end

--- a/spec/libraries/provider_samhain_service_ubuntu_legacy_spec.rb
+++ b/spec/libraries/provider_samhain_service_ubuntu_legacy_spec.rb
@@ -1,9 +1,9 @@
 # Encoding: UTF-8
 
 require_relative '../spec_helper'
-require_relative '../../libraries/provider_samhain_service_ubuntu_precise'
+require_relative '../../libraries/provider_samhain_service_ubuntu_legacy'
 
-describe Chef::Provider::SamhainService::Ubuntu::Precise do
+describe Chef::Provider::SamhainService::Ubuntu::Legacy do
   let(:name) { 'default' }
   let(:run_context) { ChefSpec::SoloRunner.new.converge.run_context }
   let(:new_resource) do
@@ -18,6 +18,14 @@ describe Chef::Provider::SamhainService::Ubuntu::Precise do
 
     context 'Ubuntu 12.04' do
       let(:platform) { { platform: 'ubuntu', version: '12.04' } }
+
+      it 'returns true' do
+        expect(res).to eq(true)
+      end
+    end
+
+    context 'Ubuntu 10.04' do
+      let(:platform) { { platform: 'ubuntu', version: '10.04' } }
 
       it 'returns true' do
         expect(res).to eq(true)


### PR DESCRIPTION
Adds compatibility with other pre-14.04 Ubuntus that either had a broken `status` action in their init script or lacked one entirely.