### PR TITLE
If the log directory is group-writable, trust group members

### DIFF
--- a/.kitchen.yml
+++ b/.kitchen.yml
@@ -20,7 +20,7 @@ platforms:
 suites:
   - name: default
     run_list:
-      - recipe[samhain::default]
+      - recipe[samhain_test]
   - name: remove
     run_list:
       - recipe[samhain_test::remove]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,8 @@ Samhain Cookbook CHANGELOG
 
 v?.?.? (????-??-??)
 -------------------
+- Get rid of errors about access to `/var/log` by granting trusted status to
+  any user with group-write access
 
 v0.4.0 (2015-12-30)
 -------------------

--- a/test/fixtures/cookbooks/samhain_test/recipes/default.rb
+++ b/test/fixtures/cookbooks/samhain_test/recipes/default.rb
@@ -1,0 +1,16 @@
+# Encoding: UTF-8
+#
+# Ensure rsyslog is installed on test instances. Newer Ubuntu Docker containers
+# come without it, so without the syslog user's group ownership of /var/log.
+#
+
+ohai 'users' do
+  plugin 'etc'
+  action :nothing
+end
+
+package 'rsyslog' do
+  notifies :reload, 'ohai[users]', :immediately
+end
+
+include_recipe 'samhain'

--- a/test/integration/default/serverspec/localhost/config_spec.rb
+++ b/test/integration/default/serverspec/localhost/config_spec.rb
@@ -13,5 +13,40 @@ describe 'samhain::default::config' do
       EOH
       expect(subject.content).to include(expected)
     end
+
+    it 'has syslog as a trusted user', if: os[:release].to_i > 12 do
+      expected = <<-EOH.gsub(/^ {8}/, '').strip
+        [Misc]
+        Daemon=yes
+        ChecksumTest=check
+        SetLoopTime=600
+        SetFileCheckTime=7200
+        SetMailTime=86400
+        SetMailNum=10
+        SetMailAddress=root@localhost
+        SetMailRelay=localhost
+        MailSubject=[Samhain at %H] %T: %S
+        SyslogFacility=LOG_LOCAL2
+        TrustedUser=syslog
+      EOH
+      expect(subject.content).to include(expected)
+    end
+
+    it 'does not have syslog as a trusted user', if: os[:release].to_i <= 12 do
+      expected = <<-EOH.gsub(/^ {8}/, '').strip
+        [Misc]
+        Daemon=yes
+        ChecksumTest=check
+        SetLoopTime=600
+        SetFileCheckTime=7200
+        SetMailTime=86400
+        SetMailNum=10
+        SetMailAddress=root@localhost
+        SetMailRelay=localhost
+        MailSubject=[Samhain at %H] %T: %S
+        SyslogFacility=LOG_LOCAL2
+      EOH
+      expect(subject.content).to include(expected)
+    end
   end
 end


### PR DESCRIPTION
The Ubuntu packages, at least, aren't compiled with any trusted UIDs, so
will fail to start when they see that syslog has write access to
/var/log but isn't trusted.

This removes the need to override that particular attribute in a wrapper cookbook up the chain.