### PR TITLE
Catch and clean up cases of duplicate trusted users

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@ Samhain Cookbook CHANGELOG
 
 Unreleased
 ----------
+- Catch and clean up cases of duplicate trusted users
 
 v0.5.0 (2016-01-09)
 -------------------

--- a/libraries/provider_samhain_config.rb
+++ b/libraries/provider_samhain_config.rb
@@ -62,7 +62,7 @@ class Chef
                 '/var/log', node['etc']['passwd'], node['etc']['group']
               )
               m = new_resource.config['Misc'].merge(
-                'TrustedUser' => us.join(',')
+                'TrustedUser' => us.uniq.join(',')
               )
               SamhainCookbook::Helpers.build_config(
                 new_resource.config.merge('Misc' => m)


### PR DESCRIPTION
If a trusted user attribute is passed in _and_ /var/log is group-writable, the generated config shouldn't list a user twice.